### PR TITLE
Issue #15 - Refresh timeline programmatically from a message channel …

### DIFF
--- a/force-app/main/default/messageChannels/TimelineRefreshData.messageChannel-meta.xml
+++ b/force-app/main/default/messageChannels/TimelineRefreshData.messageChannel-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningMessageChannel xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Allows refreshing the timeline data from an external event</description>
+    <isExposed>true</isExposed>
+    <lightningMessageFields>
+        <description>If populated, the timeline will refresh only if it matches this record id</description>
+        <fieldName>recordId</fieldName>
+    </lightningMessageFields>
+    <lightningMessageFields>
+        <description>If populated, the timeline will refresh only if it matches this config id</description>
+        <fieldName>configId</fieldName>
+    </lightningMessageFields>
+    <masterLabel>Timeline Refresh Data</masterLabel>
+</LightningMessageChannel>


### PR DESCRIPTION
…event fired from outside the managed package

You may find it easier to test it by using the boilerplate made in this branch:
https://github.com/ArielS1/ActivityTimelineLWC/tree/feature/refresh_from_event_example

by using flow Create_Case
and lwc refreshDataExample