### PR TITLE
Update RecordTimelineDataProvider.cls

### DIFF
--- a/force-app/main/default/classes/RecordTimelineDataProvider.cls
+++ b/force-app/main/default/classes/RecordTimelineDataProvider.cls
@@ -145,7 +145,7 @@ public with sharing class RecordTimelineDataProvider {
         //get the data from the record
         String soqlStmt ='';
         if(objectApiName !='ActivityHistory'){
-            soqlStmt ='select Id,'+String.join(newFieldsToQuery,',')+' from '+objectApiName+' where Id=:recordId';
+            soqlStmt ='select Id,'+String.join(newFieldsToQuery,',')+' from '+objectApiName+' where Id=:recordId ALL ROWS';
         }else{
             soqlStmt ='select Id,'+String.join(newFieldsToQuery,',')+' from Task where Id=:recordId ALL ROWS';
 


### PR DESCRIPTION
Archived Task details are not coming in the detail section of Activity Time line, It might be be due to the query is not pulling all rows is Object API name isn't Activity History which in this case might be TaskRelation.