### PR TITLE
Fix Issue Where Field Data Doesn't Populate for External Service

### DIFF
--- a/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js
+++ b/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js
@@ -141,7 +141,7 @@ export default class TimelineItemOtherObject extends LightningElement {
             });
         }
         //Data loaded via a Apex data provider so just display the data from the `externalData` attribute
-        if(this.isExternalServiceData && !this.isSalesforceObject){
+        if(this.isExternalServiceData){
             this.dataLoaded=true;
             this.fieldData = this.populateFieldData(this.externalData,this.externalDataFieldTypes);
         }


### PR DESCRIPTION
When using an Apex Class Data Provider Type, it will not populate any field data within the UI when isSalesforceObject is set to true.

Example:
<img width="1387" height="531" alt="image" src="https://github.com/user-attachments/assets/77dd8614-0c65-4dce-b306-cca24757ec5c" />

The above screenshot shows records whose child object configurations have Data Provider Type set to 'Apex Class' and isSalesforceObject set to 'true'.

To fix, I have removed the condition of checking isSalesforceObject is false within the relevant LWC. It doesn't really make sense that the field data only populates in that case.
