### PR TITLE
Update Logic to Check If External Service

### DIFF
--- a/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js
+++ b/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js
@@ -34,7 +34,7 @@ export default class TimelineItemOtherObject extends LightningElement {
     @api isOverdue=false;
     @api expanded;
     @api themeInfo;
-    @api isSalesforceObject=false;
+    @api isSalesforceObject = false; // Value can still be set by a parent component, but no longer used within this component
     @api currentUserTimezone;
     @track dataLoaded = false;
  
@@ -79,16 +79,17 @@ export default class TimelineItemOtherObject extends LightningElement {
     }
 
     @api 
-    get isExternalServiceData(){
-        if(this.isSalesforceObject){
-            return false;
-        }else{
-            return this.isDataFromExternalService;
+    get isExternalServiceData() {
+        // Check if externalData is populated (if it is then we know it's an external service)
+        if (this.externalData) {
+            return true;
         }
+        // Otherwise, return the value set by the setter (this can be passed in via other parent components)
+        return this.isDataFromExternalService;
     }
 
-    set isExternalServiceData(value){
-        this.isDataFromExternalService=value;
+    set isExternalServiceData(value) {
+        this.isDataFromExternalService = value;
     }
 
     get hasIconName() {
@@ -141,8 +142,8 @@ export default class TimelineItemOtherObject extends LightningElement {
             });
         }
         //Data loaded via a Apex data provider so just display the data from the `externalData` attribute
-        if(this.isExternalServiceData){
-            this.dataLoaded=true;
+        if (this.isExternalServiceData) {
+            this.dataLoaded = true;
             this.fieldData = this.populateFieldData(this.externalData,this.externalDataFieldTypes);
         }
     }


### PR DESCRIPTION
The isExternalServiceData getter was originally checking if 'isSalesforceObject' was true, in which case isExternalServiceData would evaluate to 'false'. Since 'isSalesforceObject' didn't exactly tell us* if we were using 'external service data', the logical fix was to change it to check if 'externalData' was truthy, in which case the getter would evaluate to 'true'.

*isSalesforceObject can be set within an Apex Class external service and be set to either true or false. Wasn't the right kind of property to check for this scenario, as we could still be dealing with an external service, even if isSalesforceObject is set to true.

Now when the handleToggleDetail method is called, it should correctly be able to determine if we are using an external service, based on isExternalServiceData now returning the correct value.

isSalesforceObject is still set via the 'timelineMonth' parent component, but is no longer used within 'timelineItemOtherObject'. Have marked this with a comment against that property.