### PR TITLE
Update activityTimeline.js

### DIFF
--- a/force-app/main/default/lwc/activityTimeline/activityTimeline.js
+++ b/force-app/main/default/lwc/activityTimeline/activityTimeline.js
@@ -301,10 +301,12 @@ export default class ActivityTimeline extends LightningElement {
                 });
                 if(tasksAndChildRecords.length>0){
                     monthItem.firstOfMonth = moment(key).format("YYYY-MM-01");
+                    var parts = monthItem.firstOfMonth.split('-');
+                    var localDate = new Date(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1, 1);
                     const formatted = new Intl.DateTimeFormat(LANG, {
                         month: 'long',
                         year: 'numeric'
-                    }).format(Date.parse(monthItem.firstOfMonth));
+                    }).format(localDate);
                     monthItem.monthValue = formatted;
                     //If the month is current month don't set the timeFromNow
                     if(!(moment(new Date()).format("YYYY-MM")===moment(monthItem.firstOfMonth).format("YYYY-MM"))){


### PR DESCRIPTION
This is a fix for Month headers not displaying properly.  If you are in a different timezone than the org you are logging into, Intl.DateTimeFormat(.....) will add or subtract X hours from monthItem.firstOfMonth, where X is UTC-X. The result is that when we are setting month value for the header, the formatted value is January 31st instead of February 1st, for instance. There are several instances where this is happening in the file, but this is the most obvious and glaring one I tackled first. By creating a local date, and using that value instead we ensure the date displays properly.