### PR TITLE
Fix for call tasks having wrong label when no WhoId

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -297,6 +297,14 @@
         <value>logged a call with</value>
     </labels>
     <labels>
+        <fullName>logged_a_call</fullName>
+        <categories>Activity Timeline</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>logged a call</shortDescription>
+        <value>logged a call</value>
+    </labels>
+    <labels>
         <fullName>logged_a_task</fullName>
         <categories>Activity Timeline</categories>
         <language>en_US</language>

--- a/force-app/main/default/lwc/timelineItemTask/timelineItemTask.html
+++ b/force-app/main/default/lwc/timelineItemTask/timelineItemTask.html
@@ -98,7 +98,7 @@
                     </p>
                     <p if:true={isCall} class="slds-var-m-horizontal_xx-small">
                         <a onclick={navigateToOwner}>{assignedToName}</a>
-                        <span if:false={hasWhoTo}> {label.logged_a_task}</span>
+                        <span if:false={hasWhoTo}> {label.logged_a_call}</span>
                         <span if:true={hasWhoTo}> {label.logged_a_call_with}&nbsp;</span>
                         <a if:true={hasWhoTo} onclick={navigateToWho}>{whoToName}</a>
                     </p>

--- a/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js
+++ b/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js
@@ -22,6 +22,7 @@ import have_a_task from '@salesforce/label/c.have_a_task';
 import created_a_task_with from '@salesforce/label/c.created_a_task_with';
 import logged_a_task from '@salesforce/label/c.logged_a_task';
 import logged_a_call_with from '@salesforce/label/c.logged_a_call_with';
+import logged_a_call from '@salesforce/label/c.logged_a_call';
 import sent_an_email from '@salesforce/label/c.sent_an_email';
 import sent_an_email_to from '@salesforce/label/c.sent_an_email_to';
 import Name from '@salesforce/label/c.Name';
@@ -81,6 +82,7 @@ export default class TimelineItemTask extends NavigationMixin(LightningElement) 
         created_a_task_with,
         logged_a_task,
         logged_a_call_with,
+        logged_a_call,
         sent_an_email,
         sent_an_email_to,
         Name,


### PR DESCRIPTION
When a task with subtype call and no WhoId was displayed on the activity timeline, it showed the label 'logged a task'. This is now changed to show the label 'logged a call', which is more in line with the behavior of Salesforce's activity timeline