### PR TITLE
commit to fix missing email from addresses

### DIFF
--- a/force-app/main/default/lwc/timelineItemTask/timelineItemTask.html
+++ b/force-app/main/default/lwc/timelineItemTask/timelineItemTask.html
@@ -103,7 +103,12 @@
                         <a if:true={hasWhoTo} onclick={navigateToWho}>{whoToName}</a>
                     </p>
                     <p if:true={isEmail} class="slds-var-m-horizontal_xx-small">
-                        <a onclick={navigateToOwner}>{assignedToName}</a>
+                        <template if:true={emailSenderUsesFromAddressOnly}>
+                            <a href={fromAddressMailtoHref}>{emailSenderDisplayName}</a>
+                        </template>
+                        <template if:false={emailSenderUsesFromAddressOnly}>
+                            <a onclick={navigateToOwner}>{emailSenderDisplayName}</a>
+                        </template>
                         <span if:false={hasWhoTo}> {label.sent_an_email}</span>
                         <span if:true={hasWhoTo}> {label.sent_an_email_to} </span>
                         <a if:true={hasWhoTo} onclick={navigateToWho}>{whoToName}</a>

--- a/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js
+++ b/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js
@@ -65,6 +65,7 @@ export default class TimelineItemTask extends NavigationMixin(LightningElement) 
     @track toAddresses;
     @track ccAddresses;
     @track firstRecipient;
+    @track fromAddress;
     @api fieldData;
     @api displayRelativeDates;
     @api taskClosedStatus;
@@ -125,7 +126,13 @@ export default class TimelineItemTask extends NavigationMixin(LightningElement) 
         if (data) {
             if (data.ActivityId) {
                 // its data from the EmailMessage object
+                if (data.FromName == null || String(data.FromName).trim() === '') {
+                    this.fromAddress = data.FromAddress;
+                } else {
+                    this.fromAddress = undefined;
+                }
                 this.assignedToName=data.FromName;
+
                 this.description=data.TextBody;
                 this.recordId=data.Id;
                 this.activityId=data.ActivityId;
@@ -219,6 +226,27 @@ export default class TimelineItemTask extends NavigationMixin(LightningElement) 
 
     get isEmail(){
         return this.taskSubtype === "Email";
+    }
+
+    get emailSenderDisplayName() {
+        if (this.assignedToName != null && String(this.assignedToName).trim() !== '') {
+            return this.assignedToName;
+        }
+        return this.fromAddress;
+    }
+
+    get emailSenderUsesFromAddressOnly() {
+        if (this.assignedToName != null && String(this.assignedToName).trim() !== '') {
+            return false;
+        }
+        return this.fromAddress != null && String(this.fromAddress).trim() !== '';
+    }
+
+    get fromAddressMailtoHref() {
+        if (!this.fromAddress) {
+            return '';
+        }
+        return `mailto:${this.fromAddress}`;
     }
 
     get hasWhoTo(){


### PR DESCRIPTION
If an email message is sent that does not have a FromName, the activity timeline will not display a from address for that email. (ex: ' sent an email to johndoe@email.com'). This pull request changes it so that if FromName is missing from EmailMessage, we instead use FromAddress. If EmailMessage does have a FromName, we preserve all the original behaviors. This change is made to be more in line with the behavior of Salesforces out of the box Activity timeline, which displays a from address even if no FromName exists. 