### PR TITLE
Adding the lightningCommunity__RelaxedCSP capability

### DIFF
--- a/force-app/main/default/lwc/activityTimeline/activityTimeline.js-meta.xml
+++ b/force-app/main/default/lwc/activityTimeline/activityTimeline.js-meta.xml
@@ -10,8 +10,10 @@
         <target>lightningCommunity__Page</target>
         <target>lightningCommunity__Default</target>
     </targets>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
     <targetConfigs>
-        
         <targetConfig targets="lightning__RecordPage">
             <property name="configId" type="String" label="Record Id, Name or External Key of the Timeline configuration to use"/>
             <property name="pageSize" type="Integer" label="Set timeline item size for each page, default 20 "/>

--- a/force-app/main/default/lwc/genericLogActivities/genericLogActivities.js-meta.xml
+++ b/force-app/main/default/lwc/genericLogActivities/genericLogActivities.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/linkedOutputText/linkedOutputText.js-meta.xml
+++ b/force-app/main/default/lwc/linkedOutputText/linkedOutputText.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineFilterPanel/timelineFilterPanel.js-meta.xml
+++ b/force-app/main/default/lwc/timelineFilterPanel/timelineFilterPanel.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItem/timelineItem.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItem/timelineItem.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItemCaseArticle/timelineItemCaseArticle.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItemCaseArticle/timelineItemCaseArticle.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItemDetail/timelineItemDetail.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItemDetail/timelineItemDetail.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItemFile/timelineItemFile.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItemFile/timelineItemFile.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItemOtherObject/timelineItemOtherObject.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js-meta.xml
+++ b/force-app/main/default/lwc/timelineItemTask/timelineItemTask.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineMonth/timelineMonth.js-meta.xml
+++ b/force-app/main/default/lwc/timelineMonth/timelineMonth.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timelineNote/timelineNote.js-meta.xml
+++ b/force-app/main/default/lwc/timelineNote/timelineNote.js-meta.xml
@@ -2,4 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
     <isExposed>false</isExposed>
+    <capabilities>
+        <capability>lightningCommunity__RelaxedCSP</capability>
+    </capabilities>
 </LightningComponentBundle>


### PR DESCRIPTION
Adding the lightningCommunity__RelaxedCSP capability to the activityTimeline LWC and all it's direct and undirect children. LWR Commerce sites can't have LWS enabled and the LWC can't be used there unless the lightningCommunity__RelaxedCSP capability is there.